### PR TITLE
Add guidance on waiting for CI/CD checks before marking PRs as ready

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -345,9 +345,25 @@ When your work is not yet ready for review:
    - This clearly indicates your PR is a work in progress
    - The PR cannot be merged until you mark it as ready for review
 
-2. When your work is complete:
+2. **IMPORTANT**: Do not mark a PR as ready for review until:
+   - All CI/CD checks are passing
+   - All pre-commit hooks have been run successfully
+   - You have addressed any automated feedback
+   - The code is fully ready for human review
+
+3. When your work is complete and all checks pass:
    - Click "Ready for Review" to convert the Draft PR to a regular PR
    - This signals to reviewers that your work is ready for their attention
+
+### CI/CD Pipeline Failures
+
+If your PR fails CI/CD checks:
+
+1. Review the failure logs carefully
+2. Fix the issues in your branch
+3. Push the changes to update the PR
+4. Verify that all checks pass before marking as ready for review
+5. If the CI/CD caught issues that should have been caught by pre-commit hooks, update the pre-commit configuration as well
 
 Draft PRs are preferred over other methods like "WIP" in titles or special branches, as they provide a standard, built-in way to indicate work in progress.
 


### PR DESCRIPTION
# Add guidance on waiting for CI/CD checks before marking PRs as ready

This PR updates the Work in Progress section in CONTRIBUTING.md to explicitly state that PRs should not be marked as ready for review until all CI/CD checks are passing.

## Changes

- Added clear guidance that PRs should remain in draft state until all CI/CD checks pass
- Added a new section on handling CI/CD pipeline failures
- Included guidance on updating pre-commit hooks when CI/CD catches issues that should have been caught locally
- Reorganized the section to emphasize the importance of this workflow

## Benefits

- Prevents reviewers from spending time on PRs that don't pass basic checks
- Encourages developers to fix CI/CD issues before requesting review
- Promotes the feedback loop between CI/CD failures and pre-commit hooks
- Establishes a clear standard for when PRs should be marked ready

## Implementation Details

The updated section now includes:
- A numbered step specifically about CI/CD checks
- A new subsection with detailed guidance on handling pipeline failures
- Clear instructions on the proper workflow

This change aligns with our goal of improving efficiency and reducing wasted resources in the development process.
